### PR TITLE
Add password hashing with passlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,12 @@ SQLite データベース `users.db` に保存されます。
 
 - Python 3.8 以上
 - `fastapi` と `uvicorn` パッケージ
+- パスワードハッシュ化に `passlib[bcrypt]`
 
 インストールは以下のコマンドを実行してください。
 
 ```bash
-pip install fastapi uvicorn
+pip install fastapi uvicorn passlib[bcrypt]
 ```
 
 ## サービスの起動方法


### PR DESCRIPTION
## Summary
- hash user passwords using passlib
- verify hashed passwords on login
- mention passlib in README install instructions

## Testing
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6844e3b1b2d08331a8d784dd6c51a0be